### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Branches:
 - released: contains original sources of all used packages.
 - master: contains all necessary changes to be able to compile with Visual Studio. From this branch the binary released are build.
 
-Currently compilation scripts assume they are run from a WSL terminal inside a windows folder (because a case insenstive filesystem is needed).
+Currently compilation scripts assume they are run from a WSL terminal inside a windows folder (because a case insensitive filesystem is needed).


### PR DESCRIPTION
@marchaesen 

I presume the top level files, and docker and releasenotes directories' files, are authored by the vcxsrv developers.

The remainder of the repo in effect being bundled code; and no purpose therefore to check those files for possible fixes.