### PR TITLE
Add fixes to dockerfile and install dotnet 4.8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 #	This also results in a 32GB docker image
 
 # Use the Long-Term Support Channel Windows Server Core image
-FROM mcr.microsoft.com/windows/server:ltsc2022
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 SHELL ["cmd", "/S", "/C"]
 
 #Install VS Community 2022; based on https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2022
@@ -35,7 +35,7 @@ RUN \
 #Install Chocolatey
 RUN powershell -NoProfile -Command \
 	Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
-	Start-Process \ProgramData\chocolatey\bin\choco.exe -ArgumentList 'feature disable –name showDownloadProgress' -Wait
+	Start-Process %ProgramData%\chocolatey\bin\choco.exe -ArgumentList 'feature disable –name showDownloadProgress' -Wait
 
 #Install Strawberry Perl into C:\Perl
 RUN choco install -y strawberryperl \
@@ -71,7 +71,7 @@ RUN choco install -y python3 --version 3.9.13 \
 	&& C:\Python39\Scripts\pip install mako \
 	&& popd \
 	&& del c:\programdata\chocolatey\lib\python3\*.nupkg \
-	&& setx /m path "%path%;C:\Python39
+	&& setx /m path "%path%;C:\Python39"
 
 #Install git
 RUN choco install -y git \
@@ -83,7 +83,7 @@ RUN choco install -y git \
 
 # Launch VS2022 developer command prompt when started
 SHELL ["cmd", "/S", "/K"]
-ENTRYPOINT ""C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat""
+ENTRYPOINT ""%ProgramFiles%\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat""
 
 # Launch with docker run -m 4G -v:<VcXSrvGit>:c:\src -it <ContainerName>
 # Once inside:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,22 +14,23 @@
 #	This also results in a 32GB docker image
 
 # Use the Long-Term Support Channel Windows Server Core image
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/server:ltsc2022
 SHELL ["cmd", "/S", "/C"]
 
-# Install VS 2022 community
-RUN powershell -NoProfile -Command \
-	Set-ExecutionPolicy Bypass -Scope Process -Force; \
-	$ProgressPreference = 'SilentlyContinue'; \
-	[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; \
-	mkdir c:\temp; \
-	Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vs_community.exe" -Outfile "C:\TEMP\vs_community.exe"; \
-	C:\TEMP\vs_community.exe --includeRecommended --includeOptional --quiet --nocache --add Microsoft.VisualStudio.Workload.NativeDesktop --norestart --wait; \
-    & IF "%ERRORLEVEL%"=="3010" dir \
-	& rd /s /q c:\temp \
-	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& del c:\temp\vs_community.exe
+#Install VS Community 2022; based on https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2022
+RUN \
+    # Download the Build Tools bootstrapper.
+    curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe \
+    \
+    # Install Build Tools with the Microsoft.VisualStudio.Workload.VCTools workload.
+    && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache \
+        --installPath "%ProgramFiles%\Microsoft Visual Studio\2022\Community" \
+        --add Microsoft.VisualStudio.Workload.VCTools;includeRecommended \
+        --add Microsoft.Net.Component.4.8.TargetingPack \
+        || IF "%ERRORLEVEL%"=="3010" EXIT 0) \
+    \
+    # Cleanup
+    && del /q vs_buildtools.exe
 
 #Install Chocolatey
 RUN powershell -NoProfile -Command \
@@ -49,32 +50,23 @@ RUN choco install -y nsis \
 	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
 	&& del c:\programdata\chocolatey\lib\nsis.install\*.nupkg
 
-#Install 7Zip
-RUN choco install -y 7zip \
-	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& del c:\programdata\chocolatey\lib\7zip.install\*.nupkg
+#Disable creating junctions
+ENV CYGWIN=winsymlinks:lnk
 
-#Install Cygwin and remove hardlinks
-#Ignore 7z exit code during compress as exit code is non-zero when junctions are omitted.
-RUN choco install -y cygwin --version 3.1.6 \
-	&& C:\ProgramData\chocolatey\lib\cygwin\tools\setup-x86.exe -q -v -P bison,flex,gawk,gperf,gzip,nasm,sed,python27,python38-lxml -W -R c:\tools\cygwin -a x86_64 \
-	&& 7z a -mx1 c:\cyg.7z c:\tools \
-	& rd /s /q c:\tools \
-	&& 7z x c:\cyg.7z \
-	&& del c:\cyg.7z \
+#Install Cygwin
+RUN choco install -y cygwin \
+	&& c:\tools\cygwin\cygwinsetup.exe -q -v -P bison,flex,gawk,gperf,gzip,nasm,sed,python27,python38-lxml -W -R c:\tools\cygwin -a x86_64 \
 	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
 	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
 	&& if exist c:\tools\cygwin\bin\link.exe ren c:\tools\cygwin\bin\link.exe link_cygwin.exe \
 	&& del c:\programdata\chocolatey\lib\cygwin\*.nupkg \
-	&& del c:\programdata\chocolatey\lib\cygwin\tools\setup-x86.exe
+	&& del c:\tools\cygwin\cygwinsetup.exe
 
 #Install Python3
-RUN choco install python3 --version 3.9.13 -y \
+RUN choco install -y python3 --version 3.9.13 \
 	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
 	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
 	&& pushd c:\python39 \
-	&& C:\Python39\Scripts\pip wheel https://files.pythonhosted.org/packages/17/78/7cc7e269c7c58f0b94c4abdf6cf2bcce2fb0ca58d415e6e4e1b805cd9f17/lxml-4.9.1-cp39-cp39-win_amd64.whl \
 	&& C:\Python39\Scripts\pip install lxml \
 	&& C:\Python39\Scripts\pip install mako \
 	&& popd \
@@ -91,13 +83,12 @@ RUN choco install -y git \
 
 # Launch VS2022 developer command prompt when started
 SHELL ["cmd", "/S", "/K"]
-ENTRYPOINT ""C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\vcvars64.bat""
+ENTRYPOINT ""C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat""
 
 # Launch with docker run -m 4G -v:<VcXSrvGit>:c:\src -it <ContainerName>
 # Once inside:
 #   git clone src vcx
 #   cygwin
 #   cd /cygdrive/c/vcx
-#   export SHELLOPTS
-#   set -o igncr
 #   ./buildall.sh 1 9 R
+#   ./copyRelease.sh


### PR DESCRIPTION
This hopefully addresses https://github.com/marchaesen/vcxsrv/issues/58, https://github.com/marchaesen/vcxsrv/issues/37, https://github.com/marchaesen/vcxsrv/issues/42  and https://github.com/marchaesen/vcxsrv/issues/19.

These are the fixes I had, which don't appear to have made it upstream.

servercore:ltsc2019 could be put back if the newer windows server 2022 breaks things.

