### PR TITLE
Document build instructions and give docker builds parity with WSL builds.

### DIFF
--- a/HOW_TO_BUILD.txt
+++ b/HOW_TO_BUILD.txt
@@ -1,33 +1,78 @@
+WSL Builds
+
 Prerequisites:
 - Visual Studio 2022 Community Edition
 - Strawberry perl portable edition installed in c:\perl
-- Cygwin (with the following packages: bison, flex, gawk, gperf, gzip, nasm, sed, python27, python38, python38-lxml)
-- Python39 with lxml and mako
+    choco install -y strawberryperl --install-arguments="INSTALLDIR=""C:\Perl"""
+- Python39 with lxml and mako:
+    choco install python39 --params "/InstallDir:C:\Python39"
+    C:\python39\Scripts\pip.exe install lxml mako pyyaml
+- WSL2
 - To build the installer: nsis
+    choco install -y nsis
+- Jom for parallell nmake builds
+- Version 2.52.5 of winflexbison unzipped into c:\winflexbison
+- Gperf: choco install gperf
 
-or make it easy on yourself and use the new Docker-based build environment:
+Then start wsl (ensuring the default default distribution is set to the one
+you're using. This is because if you have installed Docker on windows, it has a
+tendency in creating a new default distribution when running under WSL mode
+rather than HyperV mode).
 
-Run buildDocker.cmd and give it a couple hours to build the build environment.
-From inside the VcXSrv source directory, launch the build environment using
+WSL builds only work if checkout to a windows filesystem (accessible in WSL via /mnt/[drive]/path)
 
-		runDocker.cmd
+Run:
 
-When the container is up, run the following to clone the source into the container and enter the Cygwin build environment:
+  sudo apt install meson ninja-build gettext pytest pytest-xdist python-gettext
 
-		git clone src vcx
-		cygwin
-		cd /cygdrive/c/vcx
-        export SHELLOPTS
-        set -o igncr
+in WSL to install prerequisites.
 
-Now you can build a 64-bit Debug build on an 8-core system...
+Then kick off a build with:
 
-		./buildall.cmd 1 9 D
+./buildall.sh 1 9 [RDA] - Pick on of: D = Debug build, R = Release build, A = Both debug and release.
 
-buildall.sh <32/64-bit flag> <build tasks> <Debug/Release flag> [Build deps flag]
+
+Docker builds
+
+1. Switch to Windows Containers Mode:
+   Right click on docker system tray icon, and select "Switch to Windows Containers Mode"
+
+2. Docker => Settings => Docker Engine
+   (Without this the docker build will fail during VS Community install)
+   Add to Docker -> Settings -> Docker Engin:
+       "storage-opts": [
+         "size=120GB"
+       ]
+
+  Click on Apply and let it restart.
+
+
+3. Run buildDocker.cmd and give it a couple hours to build the build environment.
+
+4. Run runDocker.cmd. and then run the following to clone the source into the
+   container and enter the Cygwin build environment:
+
+	git clone src vcx
+	cygwin
+	cd /mnt/c/vcx
+
+Now you can kick off a build:
+
+        buildall.sh <32/64-bit flag> <build tasks> <Debug/Release flag> [Build deps flag]
 
 Where:
   - 32/64-bit flag - 1=64-bit, 0=32-bit
-  - build tasks is the number of parallel build tasks to run (use cpu count + 1)
+  - build tasks is the number of parallel build tasks to run (currently best left at 1
+    until jom parallel builds issues is fixed under cygwin)
   - Debug/Release flag - D=Debug, R=Release, A=All
   - optional Build deps flag - N=Only build the server
+
+After a successful build then run:
+
+  ./copyRelease.sh
+
+Or:
+
+  ./copyDebug.sh
+
+Which copies the installer and other files into release or debug directory in the vcxsrv directory outside of Docker.

--- a/HOW_TO_BUILD.txt
+++ b/HOW_TO_BUILD.txt
@@ -6,12 +6,15 @@ Prerequisites:
     choco install -y strawberryperl --install-arguments="INSTALLDIR=""C:\Perl"""
 - Python39 with lxml and mako:
     choco install python39 --params "/InstallDir:C:\Python39"
-    C:\python39\Scripts\pip.exe install lxml mako pyyaml
-- WSL2
+    C:\python39\Scripts\pip.exe install lxml mako pyyaml StrEnum pytest pytest-xdist python-gettext
+- WSL2 (Standard Ubuntu seems to do the trick)
 - To build the installer: nsis
     choco install -y nsis
-- Jom for parallell nmake builds
+- Jom for parallell nmake builds (version 1.1.4):
+    https://download.qt.io/official_releases/jom/
+  And unzip it say in c:\jom, and add c:\bin\ to PATH.
 - Version 2.52.5 of winflexbison unzipped into c:\winflexbison
+    From: https://sourceforge.net/projects/winflexbison/files/
 - Gperf: choco install gperf
 
 Then start wsl (ensuring the default default distribution is set to the one
@@ -29,7 +32,7 @@ in WSL to install prerequisites.
 
 Then kick off a build with:
 
-./buildall.sh 1 9 [RDA] - Pick on of: D = Debug build, R = Release build, A = Both debug and release.
+./buildall.sh 1 8 [RDA] - Pick on of: D = Debug build, R = Release build, A = Both debug and release.
 
 
 Docker builds
@@ -62,8 +65,7 @@ Now you can kick off a build:
 
 Where:
   - 32/64-bit flag - 1=64-bit, 0=32-bit
-  - build tasks is the number of parallel build tasks to run (currently best left at 1
-    until jom parallel builds issues is fixed under cygwin)
+  - build tasks is the number of parallel build tasks to run (8 is a good number)
   - Debug/Release flag - D=Debug, R=Release, A=All
   - optional Build deps flag - N=Only build the server
 

--- a/HOW_TO_DEBUG.md
+++ b/HOW_TO_DEBUG.md
@@ -1,0 +1,14 @@
+# HOW TO DEBUG
+
+### 1. When running the following command:
+
+  `./buildall.sh 1 9 D 2>&1 | tee build_vcxsrv.log`
+
+  The build process will generate .pdb files along with most of the internal
+  debug data inside the VcXsrv directory.
+
+### 2. Identify the module you want to debug, and use Visual Studio Community 2022.
+→ Debug → Attach to Process, then select the corresponding .exe (depending on
+which module of VcXsrv you are working on).
+### 3. Load module symbols for accurate debugging.
+### 4. Set breakpoints based on the specific tasks or behavior you want to inspect.

--- a/buildall.sh
+++ b/buildall.sh
@@ -121,7 +121,7 @@ if [[ "$BUILDDEBUG" == "1" ]] ; then
 		fi
 		cd debug64
 		perl.exe ../Configure VC-WIN64A --debug /FS
-# 	else
+ 	else
 		if [[ ! -d "debug32" ]]; then
 		  mkdir debug32
 		fi

--- a/buildall.sh
+++ b/buildall.sh
@@ -1,37 +1,41 @@
 #!/bin/bash
 
-if [[ "$1" == "1" ]] ; then
-source ./setenv.sh 1
-elif [[ "$1" == "0" ]] ; then
-source ./setenv.sh 0
+if [ "${1}" == "1" ]; then
+    IS64=1
+elif [ "${1}" == "0" ]; then
+    IS64=0
 else
-  echo "Please pass 1 (64-bit compilation) or 0 (32-bit compilation) as first argument"
-  exit
+    echo "Please pass 1 (64-bit compilation) or 0 (32-bit compilation) as first argument"
+    exit 1
 fi
-if [[ "$2" == "" ]] ; then
-  echo "Please pass number of parallel builds as second argument"
-  exit
+if [ "${2}" == "" ] ; then
+    echo "Please pass number of parallel builds as second argument"
+    exit 1
 fi
-if [[ "$3" == "" ]] ; then
-  echo "Please pass build type as third argument.  D for DEBUG, R for RELEASE, A for ALL"
-  exit
+if [ "${3}" == "" ] ; then
+    echo "Please pass build type as third argument.  D for DEBUG, R for RELEASE, A for ALL"
+    exit 1
 fi
-if [[ "$3" == "A" ]] ; then
-BUILDRELEASE=1
-BUILDDEBUG=1
+if [ "${3}" == "A" ] ; then
+    BUILDRELEASE=1
+    BUILDDEBUG=1
 fi
-if [[ "$3" == "R" ]] ; then
-BUILDRELEASE=1
-BUILDDEBUG=0
+if [ "${3}" == "R" ] ; then
+    BUILDRELEASE=1
+    BUILDDEBUG=0
 fi
-if [[ "$3" == "D" ]] ; then
-BUILDRELEASE=0
-BUILDDEBUG=1
+if [ "${3}" == "D" ] ; then
+    BUILDRELEASE=0
+    BUILDDEBUG=1
 fi
+
+source ./setenv.sh ${IS64}
+
 BUILDDEPS=1
-if [[ "$4" == "N" ]] ; then
-BUILDDEPS=0
+if [ "${4}" == "N" ] ; then
+    BUILDDEPS=0
 fi
+
 function check-error {
     errorcode=$?
     if [[ $errorcode != 0 ]]; then
@@ -42,11 +46,12 @@ function check-error {
 
 which nasm.exe > /dev/null 2>&1
 check-error 'Please install nasm'
-
 which MSBuild.exe > /dev/null 2>&1
 check-error 'Please install/set environment for visual studio 2022'
 which python.exe > /dev/null 2>&1
-check-error 'Make sure that python.exe is in the PATH. (e.g. cp /usr/bin/python2.7.exe /usr/bin/python.exe)'
+check-error 'Please install python'
+which jom.exe > /dev/null 2>&1
+check-error 'Please install jom'
 
 # c:\perl should have a copy of strawberry perl portable edition
 which perl.exe > /dev/null 2>&1
@@ -69,7 +74,7 @@ if [[ "$IS64" == "1" ]]; then
 	fi
 else
 	if [[ "$BUILDRELEASE" == "1" ]] ; then
-		echo MSBuild.exe freetype/MSBuild/freetype.sln -t:Build -p:Configuration="Release" -p:Platform=Win32 -m:$2
+		echo MSBuild.exe freetype/MSBuild.sln -t:Build -p:Configuration="Release" -p:Platform=Win32 -m:$2
 		MSBuild.exe freetype/MSBuild.sln -t:Build -p:Configuration="Release" -p:Platform=Win32 -m:$2
 		check-error 'Error compiling freetype'
 	fi
@@ -150,25 +155,25 @@ if [[ "$IS64" == "1" ]]; then
   if [[ "$BUILDDEPS" == "1" ]]; then
 
   	if [[ "$BUILDRELEASE" == "1" ]]; then
-  		MSBuild.exe tools/mhmake/mhmakevc10.sln -t:Build -p:Configuration=Release -p:Platform=x64 -m:$2
+		MSBuild.exe tools/mhmake/mhmakevc10.sln -t:Build -p:Configuration=Release -p:Platform=x64 -m:$2
       wait
   		check-error 'Error compiling mhmake for release'
   	fi
 
   	if [[ "$BUILDDEBUG" == "1" ]]; then
-  		MSBuild.exe tools/mhmake/mhmakevc10.sln -t:Build -p:Configuration=Debug -p:Platform=x64 -m:$2
+		MSBuild.exe tools/mhmake/mhmakevc10.sln -t:Build -p:Configuration=Debug -p:Platform=x64 -m:$2                  
       wait
   		check-error 'Error compiling mhmake for debug'
   	fi
   fi
 
 	if [[ "$BUILDRELEASE" == "1" ]]; then
-		tools/mhmake/Release64/mhmake.exe -P$2 -C xorg-server MAKESERVER=1
+		${MHMAKEPATH}/mhmake.exe -P$2 -C xorg-server MAKESERVER=1
 		check-error 'Error compiling vcxsrv for release'
 	fi
 
 	if [[ "$BUILDDEBUG" == "1" ]]; then
-		tools/mhmake/Release64/mhmake.exe -P$2 -C xorg-server MAKESERVER=1 DEBUG=1
+		${MHMAKEPATH}/mhmake.exe -P$2 -C xorg-server MAKESERVER=1 DEBUG=1
 		check-error 'Error compiling vcxsrv for debug'
 	fi
 
@@ -180,22 +185,22 @@ else
   if [[ "$BUILDDEPS" == "1" ]]; then
 
   	if [[ "$BUILDRELEASE" == "1" ]]; then
-  		MSBuild.exe tools/mhmake/mhmakevc10.sln -t:Build -p:Configuration=Release -p:Platform=Win32 -m:$2
+		MSBuild.exe tools/mhmake/mhmakevc10.sln -t:Build -p:Configuration=Release -p:Platform=Win32 -m:$2
       wait
   		check-error 'Error compiling mhmake for release'
   	fi
   	if [[ "$BUILDDEBUG" == "1" ]]; then
-  		MSBuild.exe tools/mhmake/mhmakevc10.sln -t:Build -p:Configuration=Debug -p:Platform=Win32 -m:$2
+		MSBuild.exe tools/mhmake/mhmakevc10.sln -t:Build -p:Configuration=Debug -p:Platform=Win32 -m:$2
       wait
   		check-error 'Error compiling mhmake for debug'
   	fi
 
   	if [[ "$BUILDRELEASE" == "1" ]]; then
-  		tools/mhmake/Release/mhmake.exe -P$2 -C xorg-server MAKESERVER=1
+		${MHMAKEPATH}/mhmake.exe -P$2 -C xorg-server MAKESERVER=1
   		check-error 'Error compiling vcxsrv for release'
   	fi
   	if [[ "$BUILDDEBUG" == "1" ]]; then
-  		tools/mhmake/Release/mhmake.exe -P$2 -C xorg-server MAKESERVER=1 DEBUG=1
+		${MHMAKEPATH}/mhmake.exe -P$2 -C xorg-server MAKESERVER=1 DEBUG=1
   		check-error 'Error compiling vcxsrv for debug'
   	fi
 

--- a/buildall.sh
+++ b/buildall.sh
@@ -95,7 +95,7 @@ if [[ "$BUILDRELEASE" == "1" ]] ; then
 		fi
 		cd release64
 
-		perl.exe ../Configure VC-WIN64A --release
+		perl.exe ../Configure VC-WIN64A --release /FS
 	else
 
 		if [[ ! -d "release32" ]]; then
@@ -103,11 +103,11 @@ if [[ "$BUILDRELEASE" == "1" ]] ; then
 		fi
 		cd release32
 
-		perl.exe ../Configure VC-WIN32 --release
+		perl.exe ../Configure VC-WIN32 --release /FS
 	fi
 	check-error 'Error executing perl'
 
-	jom.exe /J$2
+	jom.exe /J$2 || jom.exe /J1
 	check-error 'Error compiling openssl for release'
 
 	cd ../..
@@ -120,17 +120,17 @@ if [[ "$BUILDDEBUG" == "1" ]] ; then
 		  mkdir debug64
 		fi
 		cd debug64
-		perl.exe ../Configure VC-WIN64A --debug
-	else
+		perl.exe ../Configure VC-WIN64A --debug /FS
+# 	else
 		if [[ ! -d "debug32" ]]; then
 		  mkdir debug32
 		fi
 		cd debug32
-		perl.exe ../Configure VC-WIN32 --debug
+		perl.exe ../Configure VC-WIN32 --debug /FS
 	fi
 	check-error 'Error executing perl'
 
-	jom.exe /J$2
+	jom.exe /J$2 || jom.exe /J1
 	check-error 'Error compiling openssl for debug'
 
 	cd ../..

--- a/buildall.sh
+++ b/buildall.sh
@@ -85,6 +85,8 @@ else
 	fi
 fi
 
+export CFLAGS="-FS"
+
 if [[ "$BUILDRELEASE" == "1" ]] ; then
 	cd openssl
 
@@ -107,7 +109,7 @@ if [[ "$BUILDRELEASE" == "1" ]] ; then
 	fi
 	check-error 'Error executing perl'
 
-	jom.exe /J$2 || jom.exe /J1
+	jom.exe /J$2
 	check-error 'Error compiling openssl for release'
 
 	cd ../..
@@ -130,11 +132,13 @@ if [[ "$BUILDDEBUG" == "1" ]] ; then
 	fi
 	check-error 'Error executing perl'
 
-	jom.exe /J$2 || jom.exe /J1
+	jom.exe /J$2
 	check-error 'Error compiling openssl for debug'
 
 	cd ../..
 fi
+
+unset CFLAGS
 
 cd pthreads
 if [[ "$BUILDRELEASE" == "1" ]] ; then

--- a/cleanall.sh
+++ b/cleanall.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+git clean -df
+git clean -df -x -e '**/obj/'
+git clean -df -x -e '**/objs/'
+git clean -df -x -e '**/obj64/'
+git clean -df -x -e '**/obj32/'
+git clean -df -x -e '**/Release64/'
+git clean -df -x -e '**/Release/'
+git clean -df -x -e '**/Debug64/'
+git clean -df -x -e '**/Debug/'

--- a/copyDebug.sh
+++ b/copyDebug.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+rm -rf /mnt/c/src/debug
+mkdir -p /mnt/c/src/debug
+find . | grep "\(vcxsrv\(-.*-debug.*installer\)\?\.exe\|\.dll\|\.pdb\)$" | xargs -i cp {} /mnt/c/src/debug/

--- a/copyRelease.sh
+++ b/copyRelease.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+rm -rf /mnt/c/src/release
+mkdir -p /mnt/c/src/release
+find . | grep "\(vcxsrv\(-.*installer\)\?\.exe\|\.dll\)$" | grep -v debug | xargs -i cp {} /mnt/c/src/release

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,9 +29,6 @@
 # https://learn.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2022#create-and-build-the-dockerfile
 FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022
 
-# Metadata indicating an image maintainer.
-LABEL maintainer="charlie@rusbridger.com"
-
 SHELL ["cmd", "/S", "/C"]
 
 # Install VS Community 2022; based on https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2022
@@ -64,7 +61,8 @@ RUN powershell -NoProfile -Command \
 RUN choco install -y strawberryperl --install-arguments="INSTALLDIR=""C:\Perl""" \
         && refreshenv \
         && rd /s /q %TEMP% \
-        && mkdir %TEMP%
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\strawberryperl\*.nupkg
 
 # Install Nullsoft Scriptable Install System
 RUN choco install -y nsis \
@@ -116,13 +114,14 @@ ENV CYGWIN=winsymlinks:lnk
 RUN setx /M TZ "America/Los_Angeles"
 
 # Use /mnt rather than /cygdrive and treat DOS line endings same as UNIX.
-COPY fstab igncr.sh /
+COPY fstab igncr.sh c:/
 
-# Install Cygwin
+# Install Cygwin, install vim,gawk,gzip and sed. Remove python3 (windows
+# version is installed later).
 RUN choco install -y cygwin --install-arguments="INSTALLDIR=""C:\tools\cygwin"" /NoStartMenu /DesktopIcon:false" \
         && setx /m path "%path%;c:\tools\cygwin" \
         && refreshenv \
-        && cygwinsetup.exe -q -v -P vim,gawk,gzip,sed -x python3 -W -R c:\tools\cygwin -a x86_64 \
+        && cygwinsetup.exe -q -v -P vim,gawk,gzip,sed -x python3 -W -R c:\tools\cygwin -a x86_64 -n \
         && if exist c:\tools\cygwin\bin\link.exe ren c:\tools\cygwin\bin\link.exe link_cygwin.exe \
         && if exist %ChocolateyInstall%\bin\cygwin.exe ren %ChocolateyInstall%\bin\cygwin.exe choco_cygwin.exe \
         && dos2unix -n c:\fstab c:\tools\cygwin\etc\fstab \
@@ -148,8 +147,8 @@ RUN choco install -y unzip \
         && mkdir %TEMP% \
         && del %ChocolateyInstall%\lib\unzip\*.nupkg
 
-# Install jom (latest version in chocolatey is from 2015)
-RUN curl -SL --output jom.zip http://download.qt.io/official_releases/jom/jom.zip \
+# Install jom 1.1.4 (chocolatey only has a version from 2018)
+RUN curl -SL --output jom.zip https://download.qt.io/official_releases/jom/jom_1_1_3.zip \
         && unzip -d jom jom.zip \
         && setx /m path "%path%;c:\jom" \
         && del jom.zip
@@ -166,6 +165,8 @@ RUN curl -SL --output gettext.zip https://github.com/mlocati/gettext-iconv-windo
         && setx /m path "%path%;c:\gettext\bin" \
         && del gettext.zip
 
+SHELL ["cmd", "/S", "/K"]
+
 # Ensure any local changes have been committed to git
 #
 # Launch with: runDocker.cmd
@@ -175,7 +176,7 @@ RUN curl -SL --output gettext.zip https://github.com/mlocati/gettext-iconv-windo
 #   git clone src vcx
 #   cygwin
 #   cd /mnt/c/vcx
-#   ./buildall.sh 1 1 R (Currently openssl has issues with parallel builds)
+#   ./buildall.sh 1 8 R
 #   ./copyRelease.sh
 #
 # For debug builds best to ensure paths are the same, so:
@@ -184,5 +185,5 @@ RUN curl -SL --output gettext.zip https://github.com/mlocati/gettext-iconv-windo
 #   git clone src <path on the outside>, replacing d: etc with /mnt/d/...
 #   cygwin
 #   cd /mnt/c/vcx
-#   ./buildall.sh 1 1 D (Currently openssl has issues with parallel builds)
+#   ./buildall.sh 1 8 D
 #   ./copyDebug.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -148,7 +148,7 @@ RUN choco install -y unzip \
         && del %ChocolateyInstall%\lib\unzip\*.nupkg
 
 # Install jom 1.1.4 (chocolatey only has a version from 2018)
-RUN curl -SL --output jom.zip https://download.qt.io/official_releases/jom/jom_1_1_3.zip \
+RUN curl -SL --output jom.zip https://download.qt.io/official_releases/jom/jom_1_1_4.zip \
         && unzip -d jom jom.zip \
         && setx /m path "%path%;c:\jom" \
         && del jom.zip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,94 +1,188 @@
 # USAGE NOTES:
 #
-# Step 1) Switch to Windows Containers Mode
+# Step 1) Switch to Windows Containers Mode:
+#         Right click on docker system tray icon, and select "Switch to Windows Containers Mode"
 #
-# Step 2) Docker => Settings => Daemon => Switch from Basic to Advanced
-#	(Without this the docker build will fail during VS Community install)
+# Step 2) Docker => Settings => Docker Engine
+#        (Without this the docker build will fail during VS Community install)
 #      Add :
 #           "storage-opts": [
 #             "size=120GB"
 #           ]
 #
-# Step 3) docker image build -t vcxsrv/build-env -m 2GB .
-#	(This can take a couple hours and looks frozen soon after starting.  Let it have more memory if you can.)
-#	This also results in a 32GB docker image
+# Step 3) dockerBuild.cmd
+#        (This can take a couple hours and looks frozen soon after starting.  Let it have more memory if you can.)
+#        This also results in a 32GB docker image
 
-# Use the Long-Term Support Channel Windows Server Core image
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+# Use .net 4.8 with Long-Term Support Channel Windows Server Core Image 2022
+# (ltsc 2019 does not like cygwin).
+#
+# This is used as microsoft state:
+#
+# "If you base your image directly on microsoft/windowsservercore, the .NET
+# Framework might not install properly and no install error is indicated.
+# Managed code might not run after the install is complete. Instead, base your
+# image on microsoft/dotnet-framework:4.8 or later."
+#
+# Full tag list: https://mcr.microsoft.com/v2/dotnet/framework/runtime/tags/list
+#
+# https://learn.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2022#create-and-build-the-dockerfile
+FROM mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022
+
+# Metadata indicating an image maintainer.
+LABEL maintainer="charlie@rusbridger.com"
+
 SHELL ["cmd", "/S", "/C"]
 
-#Install VS Community 2022; based on https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2022
+# Install VS Community 2022; based on https://docs.microsoft.com/en-us/visualstudio/install/build-tools-container?view=vs-2022
 RUN \
     # Download the Build Tools bootstrapper.
     curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe \
     \
-    # Install Build Tools with the Microsoft.VisualStudio.Workload.VCTools workload.
+    # From: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022#desktop-development-with-c
+    # Install Build Tools with the Microsoft.VisualStudio.Workload.VCTools workload, excluding workloads and components with known issues.
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache \
         --installPath "%ProgramFiles%\Microsoft Visual Studio\2022\Community" \
         --add Microsoft.VisualStudio.Workload.VCTools;includeRecommended \
-        --add Microsoft.Net.Component.4.8.TargetingPack \
+        --add Microsoft.VisualStudio.Component.Windows10SDK.19041 \
+        --remove Microsoft.VisualStudio.Component.Windows11SDK.26100 \
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 \
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 \
+        --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 \
+        --remove Microsoft.VisualStudio.Component.Windows81SDK \
         || IF "%ERRORLEVEL%"=="3010" EXIT 0) \
     \
     # Cleanup
     && del /q vs_buildtools.exe
 
-#Install Chocolatey
+# Install Chocolatey
 RUN powershell -NoProfile -Command \
-	Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
-	Start-Process %ProgramData%\chocolatey\bin\choco.exe -ArgumentList 'feature disable –name showDownloadProgress' -Wait
+        Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')); \
+        Start-Process %ProgramData%\chocolatey\bin\choco.exe -ArgumentList 'feature disable –name showDownloadProgress' -Wait
 
-#Install Strawberry Perl into C:\Perl
-RUN choco install -y strawberryperl \
-	&& ren Strawberry Perl \
-	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& setx /m path "%path%;c:\perl\perl\bin"
+# Install Strawberry Perl into C:\Perl
+RUN choco install -y strawberryperl --install-arguments="INSTALLDIR=""C:\Perl""" \
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP%
 
-#Install Nullsoft Scriptable Install System
+# Install Nullsoft Scriptable Install System
 RUN choco install -y nsis \
-	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& del c:\programdata\chocolatey\lib\nsis.install\*.nupkg
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\nsis.install\*.nupkg
 
-#Disable creating junctions
+# Install meson
+RUN choco install -y meson \
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\meson\*.nupkg
+
+# Install ninja
+RUN choco install -y ninja \
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\ninja\*.nupkg
+
+# Install gperf
+RUN choco install -y gperf \
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\gperf\*.nupkg
+
+# Install dos2unix
+RUN choco install -y dos2unix \
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\dos2unix\*.nupkg
+
+# Install Python3
+RUN choco install -y python39 \
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && pip install lxml mako pyyaml StrEnum pytest pytest-xdist python-gettext \
+        && del %ChocolateyInstall%\lib\python39\*.nupkg
+
+# Disable creating junctions
 ENV CYGWIN=winsymlinks:lnk
 
-#Install Cygwin
-RUN choco install -y cygwin \
-	&& c:\tools\cygwin\cygwinsetup.exe -q -v -P bison,flex,gawk,gperf,gzip,nasm,sed,python27,python38-lxml -W -R c:\tools\cygwin -a x86_64 \
-	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& if exist c:\tools\cygwin\bin\link.exe ren c:\tools\cygwin\bin\link.exe link_cygwin.exe \
-	&& del c:\programdata\chocolatey\lib\cygwin\*.nupkg \
-	&& del c:\tools\cygwin\cygwinsetup.exe
+# Set the timezone to match container for cygwin
+RUN setx /M TZ "America/Los_Angeles"
 
-#Install Python3
-RUN choco install -y python3 --version 3.9.13 \
-	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& pushd c:\python39 \
-	&& C:\Python39\Scripts\pip install lxml \
-	&& C:\Python39\Scripts\pip install mako \
-	&& popd \
-	&& del c:\programdata\chocolatey\lib\python3\*.nupkg \
-	&& setx /m path "%path%;C:\Python39"
+# Use /mnt rather than /cygdrive and treat DOS line endings same as UNIX.
+COPY fstab igncr.sh /
 
-#Install git
+# Install Cygwin
+RUN choco install -y cygwin --install-arguments="INSTALLDIR=""C:\tools\cygwin"" /NoStartMenu /DesktopIcon:false" \
+        && setx /m path "%path%;c:\tools\cygwin" \
+        && refreshenv \
+        && cygwinsetup.exe -q -v -P vim,gawk,gzip,sed -x python3 -W -R c:\tools\cygwin -a x86_64 \
+        && if exist c:\tools\cygwin\bin\link.exe ren c:\tools\cygwin\bin\link.exe link_cygwin.exe \
+        && if exist %ChocolateyInstall%\bin\cygwin.exe ren %ChocolateyInstall%\bin\cygwin.exe choco_cygwin.exe \
+        && dos2unix -n c:\fstab c:\tools\cygwin\etc\fstab \
+        && dos2unix -n c:\igncr.sh c:\tools\cygwin\etc\profile.d\ingcr.sh \
+        && del c:\fstab c:\igncr.sh \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\cygwin\*.nupkg
+
+# Install git
 RUN choco install -y git \
-	&& rd /s /q C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& mkdir C:\Users\ContainerAdministrator\AppData\Local\Temp \
-	&& refreshenv \
-	&& git config --global core.autocrlf false \
-	&& del c:\programdata\chocolatey\lib\git.install\*.nupkg
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\git.install\*.nupkg \
+        && git config --global core.autocrlf true \
+        && git config --global --add safe.directory C:/src/.git
 
-# Launch VS2022 developer command prompt when started
-SHELL ["cmd", "/S", "/K"]
-ENTRYPOINT ""%ProgramFiles%\\Microsoft Visual Studio\\2022\\Community\\VC\\Auxiliary\\Build\\vcvars64.bat""
+# Install unzip
+RUN choco install -y unzip \
+        && refreshenv \
+        && rd /s /q %TEMP% \
+        && mkdir %TEMP% \
+        && del %ChocolateyInstall%\lib\unzip\*.nupkg
 
-# Launch with docker run -m 4G -v:<VcXSrvGit>:c:\src -it <ContainerName>
+# Install jom (latest version in chocolatey is from 2015)
+RUN curl -SL --output jom.zip http://download.qt.io/official_releases/jom/jom.zip \
+        && unzip -d jom jom.zip \
+        && setx /m path "%path%;c:\jom" \
+        && del jom.zip
+
+# Install winflexbison (latest version in chocolatey is 2.5.24 which doesn't work for mhmake)
+RUN curl -SL --output win_flex_bison.zip https://github.com/lexxmark/winflexbison/releases/download/v2.5.25/win_flex_bison-2.5.25.zip \
+        && unzip -d c:\winflexbison win_flex_bison.zip \
+        && setx /m path "%path%;c:\winflexbison" \
+        && del win_flex_bison.zip
+
+# Install gettext-iconv-windows
+RUN curl -SL --output gettext.zip https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.25.1-v1.17/gettext0.25.1-iconv1.17-static-64.zip \
+        && unzip -d c:\gettext gettext.zip \
+        && setx /m path "%path%;c:\gettext\bin" \
+        && del gettext.zip
+
+# Ensure any local changes have been committed to git
+#
+# Launch with: runDocker.cmd
+# Or docker run -m 4G -v:<VcXSrvGit>:c:\src -it vcxb
+#
 # Once inside:
 #   git clone src vcx
 #   cygwin
-#   cd /cygdrive/c/vcx
-#   ./buildall.sh 1 9 R
+#   cd /mnt/c/vcx
+#   ./buildall.sh 1 1 R (Currently openssl has issues with parallel builds)
 #   ./copyRelease.sh
+#
+# For debug builds best to ensure paths are the same, so:
+# 
+# Once inside:
+#   git clone src <path on the outside>, replacing d: etc with /mnt/d/...
+#   cygwin
+#   cd /mnt/c/vcx
+#   ./buildall.sh 1 1 D (Currently openssl has issues with parallel builds)
+#   ./copyDebug.sh

--- a/docker/fstab
+++ b/docker/fstab
@@ -1,0 +1,8 @@
+# /etc/fstab
+#
+#    This file is read once by the first process in a Cygwin process tree.
+#    To pick up changes, restart all Cygwin processes.  For a description
+#    see https://cygwin.com/cygwin-ug-net/using.html#mount-table
+
+# This is changing /cygdrive to /mnt
+none /mnt cygdrive binary,posix=0,user 0 0

--- a/docker/igncr.sh
+++ b/docker/igncr.sh
@@ -1,0 +1,2 @@
+export SHELLOPTS
+set -o igncr

--- a/dockerBuild.cmd
+++ b/dockerBuild.cmd
@@ -1,4 +1,3 @@
 @echo off
-pushd docker
 echo Go for a nice two hour walk while this builds
-docker build -m 4G -t vcxb .
+docker build -m 4G -t vcxb docker

--- a/runDocker.cmd
+++ b/runDocker.cmd
@@ -1,7 +1,1 @@
-@echo off
-set drive=%~d0%
-set pathpart=%~p0%
-set map=%drive%%pathpart:~0,-1%
-echo on
-
-docker run -m 4G -v%map%:c:\src -it vcxb
+docker run -m 4G -v.:c:\src -it vcxb

--- a/setenv.py
+++ b/setenv.py
@@ -1,5 +1,4 @@
-import os,sys
-
+import os
 import sys
 import subprocess
 
@@ -29,7 +28,7 @@ def escapepath(val):
   paths=val.split(";")
   newpath=[]
   for path in paths:
-    if not path in tmp:
+    if path not in tmp:
       tmp[path]=1
       path=path.replace("c:","/mnt/c")
       path=path.replace("C:","/mnt/c")
@@ -47,8 +46,11 @@ os.remove("env_after.txt")
 
 wslenv="Path/l:PATH/l"
 for var,val in env_after.items():
-  if not var in env_before:
-    print("export %s=%s"%(var,escapepath(val)))
+  if var not in env_before:
+    if os.environ.get("CYGWIN"):
+      print(f"export {var}={escape(val)}")
+    else:
+      print(f"export {var}={escapepath(val)}")
     wslenv+=":"+var+"/l"
   else:
     oldval=env_before[var]
@@ -56,10 +58,10 @@ for var,val in env_after.items():
       if var.lower()!="path":
         pass
         # currently only allow path to be different
-        #print var,"different"
-        #print oldval
-        #print val
+        #print(var,"different")
+        #print(oldval)
+        #print(val)
       else:
-        print("export PATH=%s"%(escapepath(val)))
+        print(f"export PATH={escapepath(val)}")
 print("export WSLENV="+wslenv)
 

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,20 +1,44 @@
 #!/bin/bash
 
+if [ "${1}" == "1" ]; then
+    export IS64=1
+elif [ "${1}" == "0" ]; then
+    export IS64=0
+else
+    echo "Please pass 1 (64-bit compilation) or 0 (32-bit compilation) as first argument"
+    exit 1
+fi
+
+export MHMAKEPATH
+if [ "${BUILDDEBUG}" == "1" ] ; then
+    MHMAKEPATH="tools/mhmake/Debug"
+fi
+if [ "${BUILDRELEASE}" == "1" ] ; then
+    MHMAKEPATH="tools/mhmake/Release"
+fi
+if [ "${IS64}" == "1" ]; then
+    MHMAKEPATH="${MHMAKEPATH}64"
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 rm -f commands.sh
 python setenv.py $1 > commands.sh
 chmod +x commands.sh
 source commands.sh
-if [[ "$1" == "1" ]] ; then
-export PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:$DIR/tools/mhmake/Release64:/mnt/c/nasm:$PATH:/mnt/c/gnuwin32/bin:/mnt/c/perl/perl/bin
+
+if [ -z "${CYGWIN}" ]; then
+    # WSL build.
+    export PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:${DIR}/${MHMAKEPATH}:/mnt/c/nasm:$PATH:/mnt/c/gnuwin32/bin:/mnt/c/perl/perl/bin
+    export MHMAKECONF=${DIR}
+    export PYTHON3=/mnt/c/Python39/python.exe
+    export WSLENV="${WSLENV}:MHMAKECONF/l:PYTHON3/l:IS64/l:CFLAGS/l:TERM"
 else
-export PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/lib/wsl/lib:$DIR/tools/mhmake/Release:/mnt/c/nasm:$PATH:/mnt/c/gnuwin32/bin:/mnt/c/perl/perl/bin
+    # Docker cygwin build - $PATH is setup in Dockerfile so no need to set it here.
+    export PATH=${DIR}/${MHMAKEPATH}:$PATH
+    export MHMAKECONF=$(cygpath -w ${DIR})
+    export PYTHON3=python
 fi
 rm -f commands.sh
-export MHMAKECONF=$DIR
-export PYTHON3=/mnt/c/Python39/python.exe
-export IS64=$1
-
 export CFLAGS="-FS"
-export WSLENV="$WSLENV:MHMAKECONF/l:PYTHON3/l:IS64/l:CFLAGS/l"
+

--- a/setenv.sh
+++ b/setenv.sh
@@ -40,5 +40,3 @@ else
     export PYTHON3=python
 fi
 rm -f commands.sh
-export CFLAGS="-FS"
-

--- a/xorg-server/dix/makefile
+++ b/xorg-server/dix/makefile
@@ -49,6 +49,6 @@ libdix_la_SOURCES = 	\
 	window.c
 
 initatoms.c:
-	wsl ./generate-atoms BuiltInAtoms $(notdir $@)
+	bash.exe ./generate-atoms BuiltInAtoms $(notdir $@)
 
 CSRCS = $(filter %.c,$(libdix_la_SOURCES)) $(filter %.c,$(libmain_la_SOURCES))

--- a/xorg-server/xkeyboard-config/build.sh
+++ b/xorg-server/xkeyboard-config/build.sh
@@ -1,3 +1,11 @@
-meson -D=xorg-rules-copy=true --prefix=$(realpath ../xkbdata) builddir
-cd builddir; meson compile; meson install
+if [ -d builddir ]; then
+  rm -rf builddir
+fi
 
+if [ -z "${CYGWIN}" ]; then
+  meson setup --prefix=$(realpath ../xkbdata) builddir
+else
+  meson setup --prefix=$(cygpath -w ../xkbdata) builddir
+fi
+meson compile -C builddir
+meson install -C builddir

--- a/xorg-server/xkeyboard-config/makefile
+++ b/xorg-server/xkeyboard-config/makefile
@@ -2,17 +2,19 @@ ifeq ($(MAKESERVER),1)
 $(error Please do not specify MAKESERVER=1)
 endif
 
-DESTDIR=$(MHMAKECONF)\xorg-server\xkbdata
-
-$(DESTDIR):
-	mkdir -p $(DESTDIR)
-	wsl ./build.sh
+XKBDATADIR=$(MHMAKECONF)\xorg-server\xkbdata
 
 SUBDIRS = compat geometry keycodes symbols types
 
 load_makefile $(SUBDIRS:%=%\makefile MAKESERVER=0 DEBUG=$(DEBUG);)
 
-$(SUBDIRS:%=%\all): $(DESTDIR)
-
 all: $(SUBDIRS:%=%\all)
 
+$(SUBDIRS:%=%\all): $(XKBDATADIR)
+
+$(XKBDATADIR):
+	mkdir $@
+	bash.exe ./build.sh
+	copy ..\xkbdata\rules\base ..\xkbdata\rules\xorg
+	copy ..\xkbdata\rules\base.xml ..\xkbdata\rules\xorg.xml
+	copy ..\xkbdata\rules\base.lst ..\xkbdata\rules\xorg.lst


### PR DESCRIPTION
This is for https://github.com/marchaesen/vcxsrv/issues/61, and I've split it up into separate commits which each addresses a different problem/solution that I'll list here.

1. Update the docker build environment with new dependencies introduced in the last two years. This consists of https://github.com/marchaesen/vcxsrv/commit/1889c0cbd82dd3d30844b4c032b3cdba36aa06a0 which adds back the copy*.sh shell scripts that copy a build artifacts outside the container, and adds a `cleanall.sh` and other minor files. https://github.com/marchaesen/vcxsrv/commit/751c568b3cc4fde92a846e1bb1bd88da84a757c5 is unfortunately a separate commit that updates Dockerfile and the scripts to create the container and to run the container.
2. Update the `build` and `setenv` with a small refactor I hope makes them clearer, and adds in docker/cygwin environment build support: https://github.com/marchaesen/vcxsrv/commit/4113846512a6782f55d58e5d38a1e6789d898546
3. Dix makefile update: This contains the command `wls` to run commands in a Linux-like environment. This does not work with cygwin, but I discovered with WSL that `bash` is equivalent - and in addition works with cygwin: https://github.com/marchaesen/vcxsrv/commit/965ea5ede6a3cdbf388e0468dd25562737158b3c
4. `xkeyboard-config` proved to be problematic with both WSL and docker/cygwin builds. For example, `$(DESTDIR)` redefined the rule in `makefile.after` (which caused the debug build of `mhmake` to stop with a redefined rule). Also, with the addition of `-D=xorg-rules-copy=true` added to `meson.build` caused issues running `cp`. There appeared to be a race condition whereby `$(DESTDIR)` wasn't created before going into the `compat` subdirectory that cased a silent failure. As well as these, `realpath` didn't work with cygwin (it needed a `cygpath -w` since cygwin lacks the ability to transform environment variables between windows-like path and unix-like paths which WSL has the `WSLENV` environment variable to control. This is what https://github.com/marchaesen/vcxsrv/commit/431dfd8d360cac9d4bd340c835d286120768c720 addresses.
5. Documentation is updated in https://github.com/marchaesen/vcxsrv/commit/1d892e7cf6760d2bbd5a4ef83161acdf33602281.
6. OpenSSL and `jom` parallel builds ~never worked for me - I'd like to understand if I'm missing anything, and this is a controversial change. What it does is attempts a parallel build first, and if that fails, it retries it with one `jom` process. This allows parallel builds to continue to be used to build the rest of vcxrv: https://github.com/marchaesen/vcxsrv/commit/601644f27182e97ba324af5e4e3f956e72ded338 and https://github.com/marchaesen/vcxsrv/commit/b8532d97806d3a10ad759cb6f1c4c7d0c9ac08e2.~ Now work again, so removed.
7. An unfortunate type was introduced, which https://github.com/marchaesen/vcxsrv/commit/55485808ba7a392e014b459ed5ff4342a182b463 addresses.

To be added:

- [x]  A short `HOW_TO_DEBUG.md` which documents @minhtk1's approach to debugging vcsrv. Done - based on: https://github.com/marchaesen/vcxsrv/issues/57#issuecomment-3157153307 ~@minhtk1 anything you'd like to add? Feel free to push to this PR - otherwise~ we're good for @marchaesen to have a look when he has some time.