### PR TITLE
Fix SDL2 relative mouse mode: Raw Input, cursor confinement, and cursor hiding

### DIFF
--- a/xorg-server/hw/xwin/win.h
+++ b/xorg-server/hw/xwin/win.h
@@ -86,6 +86,7 @@
  */
 #define WIN_E3B_TIMER_ID		1
 #define WIN_POLLING_MOUSE_TIMER_ID	2
+#define WIN_CLIPCURSOR_TIMER_ID        3
 
 #define MOUSE_POLLING_INTERVAL		50
 
@@ -530,6 +531,7 @@ extern int g_patternROP[];
 extern const char *g_pszQueryHost;
 extern DeviceIntPtr g_pwinPointer;
 extern DeviceIntPtr g_pwinKeyboard;
+extern HWND g_hwndGrabWindow;
 
 /*
  * Extern declares for dynamically loaded library function pointers

--- a/xorg-server/hw/xwin/win.h
+++ b/xorg-server/hw/xwin/win.h
@@ -792,6 +792,9 @@ winMouseButtonsHandle(ScreenPtr pScreen,
 void
  winEnqueueMotion(int x, int y);
 
+void
+ winEnqueueRawMotion(int dx, int dy);
+
 /*
  * winscrinit.c
  */

--- a/xorg-server/hw/xwin/wincursor.c
+++ b/xorg-server/hw/xwin/wincursor.c
@@ -199,24 +199,14 @@ winLoadCursor(ScreenPtr pScreen, CursorPtr pCursor, int screen)
     memset(pAnd, 0xFF, nBytes);
     pXor = calloc(1, nBytes);
 
-    /* Convert the X11 bitmap to a win32 bitmap
-     * The first is for an empty mask */
-    if (pCursor->bits->emptyMask) {
-        int x, y, xmax = bits_to_bytes(nCX);
-
-        for (y = 0; y < nCY; ++y)
-            for (x = 0; x < xmax; ++x) {
-                int nWinPix = bits_to_bytes(pScreenPriv->cursor.sm_cx) * y + x;
-                int nXPix = BitmapBytePad(pCursor->bits->width) * y + x;
-
-                pAnd[nWinPix] = 0;
-                if (fReverse)
-                    pXor[nWinPix] = reverse(~pCursor->bits->source[nXPix]);
-                else
-                    pXor[nWinPix] = reverse(pCursor->bits->source[nXPix]);
-            }
-    }
-    else {
+    /* Convert the X11 bitmap to a win32 bitmap.
+     * A cursor whose mask is all zeros must not be displayed at all
+     * (see dix/cursor.c CheckForEmptyMask: "We check for empty cursors
+     * so that we won't have to display them"). Keep the AND mask
+     * all-ones (0xFF) and the XOR mask all-zeros so the resulting
+     * Win32 cursor is fully transparent -- this is what X clients
+     * such as SDL rely on to hide the mouse pointer. */
+    if (!pCursor->bits->emptyMask) {
         int x, y, xmax = bits_to_bytes(nCX);
 
         for (y = 0; y < nCY; ++y)
@@ -603,6 +593,15 @@ winInitCursor(ScreenPtr pScreen)
     {
         pScreenPriv->cursor.spriteFuncs = pPointPriv->spriteFuncs;
         pPointPriv->spriteFuncs = &winSpriteFuncsRec;
+
+        /* Win32 cursors can be fully transparent, so let empty-mask
+         * cursors reach winSetCursor/winLoadCursor instead of being
+         * converted to NullCursor by miPointerUpdateSprite -- the same
+         * approach as xf86 HARDWARE_CURSOR_SHOW_TRANSPARENT. Together
+         * with the transparent rendering in winLoadCursor this makes
+         * "hide the cursor" (e.g. SDL's empty 1x1 cursor) actually
+         * work in the default (hardware cursor) mode. */
+        pPointPriv->showTransparent = TRUE;
     }
     pScreenPriv->cursor.handle = NULL;
     pScreenPriv->cursor.visible = FALSE;

--- a/xorg-server/hw/xwin/winmouse.c
+++ b/xorg-server/hw/xwin/winmouse.c
@@ -68,9 +68,6 @@ static void (*winOrigMasterDeactivateGrab)(DeviceIntPtr) = NULL;
 static void (*winOrigSlaveActivateGrab)(DeviceIntPtr, GrabPtr, TimeStamp, Bool) = NULL;
 static void (*winOrigSlaveDeactivateGrab)(DeviceIntPtr) = NULL;
 
-/* Grab nesting depth counter */
-static int winGrabDepth = 0;
-
 /* HWND of the vcxsrv window that currently has the mouse. */
 HWND g_hwndGrabWindow = NULL;
 
@@ -143,7 +140,6 @@ winMasterActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoG
     if (winOrigMasterActivateGrab)
         winOrigMasterActivateGrab(dev, grab, time, autoGrab);
 
-    winGrabDepth++;
     /* Only confine cursor position if grab specifies a confine window. */
     if (grab && grab->confineTo) {
         /* Map X11 grab window to Windows hwnd for precise constraint. */
@@ -158,10 +154,9 @@ winMasterActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoG
         if (!g_grabTimerId && g_hwndGrabWindow) {
             g_grabTimerId = SetTimer(g_hwndGrabWindow, WIN_CLIPCURSOR_TIMER_ID, 10, NULL);
         }
+        winGrabHideCursor();
     }
-
-    /* Always hide cursor during grab, regardless of confineTo */
-    winGrabHideCursor();
+    /* confineTo=None: no Windows-side effect */
 }
 
 /*
@@ -170,12 +165,12 @@ winMasterActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoG
 static void
 winMasterDeactivateGrab(DeviceIntPtr dev)
 {
-    winGrabDepth--;
-    if (winGrabDepth <= 0) {
-        winGrabDepth = 0;
+    /* dev->deviceGrab.grab points to the grab being released. */
+    GrabPtr grab = dev->deviceGrab.grab;
+    /* Confining grab: release Windows cursor state */
+    if (grab && grab->confineTo) {
         winReleaseCursorConstraint();
         winGrabShowCursor();
-
         /* Stop periodic timer */
         if (g_grabTimerId) {
             KillTimer(g_hwndGrabWindow, g_grabTimerId);
@@ -197,7 +192,6 @@ winSlaveActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoGr
     if (winOrigSlaveActivateGrab)
         winOrigSlaveActivateGrab(dev, grab, time, autoGrab);
 
-    winGrabDepth++;
     /* Only confine cursor position if grab specifies a confine window. */
     if (grab && grab->confineTo) {
         /* Map X11 grab window to Windows hwnd for precise constraint. */
@@ -212,9 +206,11 @@ winSlaveActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoGr
         if (!g_grabTimerId && g_hwndGrabWindow) {
             g_grabTimerId = SetTimer(g_hwndGrabWindow, WIN_CLIPCURSOR_TIMER_ID, 10, NULL);
         }
+        winGrabHideCursor();
     }
-    winGrabHideCursor();
+    /* confineTo=None: no Windows-side effect */
 }
+
 
 /*
  * Slave device DeactivateGrab hook.
@@ -222,12 +218,12 @@ winSlaveActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoGr
 static void
 winSlaveDeactivateGrab(DeviceIntPtr dev)
 {
-    winGrabDepth--;
-    if (winGrabDepth <= 0) {
-        winGrabDepth = 0;
+    /* dev->deviceGrab.grab points to the grab being released. */
+    GrabPtr grab = dev->deviceGrab.grab;
+    /* Confining grab: release Windows cursor state */
+    if (grab && grab->confineTo) {
         winReleaseCursorConstraint();
         winGrabShowCursor();
-
         /* Stop periodic timer */
         if (g_grabTimerId) {
             KillTimer(g_hwndGrabWindow, g_grabTimerId);
@@ -355,10 +351,12 @@ winMouseProc(DeviceIntPtr pDeviceInt, int iState)
     case DEVICE_OFF:
         pDevice->on = FALSE;
 
-        if (winGrabDepth > 0) {
-            winGrabDepth = 0;
-            winReleaseCursorConstraint();
-            winGrabShowCursor();
+        /* Force release cursor constraint on device shutdown */
+        winReleaseCursorConstraint();
+        winGrabShowCursor();
+        if (g_grabTimerId) {
+            KillTimer(g_hwndGrabWindow, g_grabTimerId);
+            g_grabTimerId = 0;
         }
         break;
     }

--- a/xorg-server/hw/xwin/winmouse.c
+++ b/xorg-server/hw/xwin/winmouse.c
@@ -48,6 +48,7 @@
 #include "xserver-properties.h"
 #include "inpututils.h"
 
+#include "winwindow.h"   /* for winGetWindowPriv, winPrivWinRec */
 
 /* Prevent POINTER_ABSOLUTE events from generating XI_RawMotion.
  * Only POINTER_RELATIVE events should produce XI_RawMotion for
@@ -70,6 +71,12 @@ static void (*winOrigSlaveDeactivateGrab)(DeviceIntPtr) = NULL;
 /* Grab nesting depth counter */
 static int winGrabDepth = 0;
 
+/* HWND of the vcxsrv window that currently has the mouse. */
+HWND g_hwndGrabWindow = NULL;
+
+/* Timer ID for periodic ClipCursor re-apply */
+static UINT_PTR g_grabTimerId = 0;
+
 /*
  * Apply cursor constraint to foreground window
  */
@@ -79,13 +86,20 @@ winApplyCursorConstraint(void)
     HWND hwnd;
     RECT rect;
 
-    hwnd = GetForegroundWindow();
+    hwnd = g_hwndGrabWindow;
+    if (!hwnd)
+        hwnd = GetForegroundWindow();
     if (!hwnd)
         return;
 
     GetClientRect(hwnd, &rect);
     ClientToScreen(hwnd, (LPPOINT)&rect.left);
     ClientToScreen(hwnd, (LPPOINT)&rect.right);
+    /* 1px padding: keep cursor away from sizing border */
+    rect.left   += 1;
+    rect.top    += 1;
+    rect.right  -= 1;
+    rect.bottom -= 1;
     ClipCursor(&rect);
 }
 
@@ -130,7 +144,23 @@ winMasterActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoG
         winOrigMasterActivateGrab(dev, grab, time, autoGrab);
 
     winGrabDepth++;
-    winApplyCursorConstraint();
+    /* Only confine cursor position if grab specifies a confine window. */
+    if (grab && grab->confineTo) {
+        /* Map X11 grab window to Windows hwnd for precise constraint. */
+        WindowPtr pGrabWin = grab->confineTo ? grab->confineTo : grab->window;
+        winPrivWinPtr pWinPriv = winGetWindowPriv(pGrabWin);
+        if (pWinPriv && pWinPriv->hWnd) {
+            g_hwndGrabWindow = pWinPriv->hWnd;
+        }
+        winApplyCursorConstraint();
+        /* Windows may silently cancel ClipCursor (Win key,
+         * cursor skipping, etc.). This timer defends against it. */
+        if (!g_grabTimerId && g_hwndGrabWindow) {
+            g_grabTimerId = SetTimer(g_hwndGrabWindow, WIN_CLIPCURSOR_TIMER_ID, 10, NULL);
+        }
+    }
+
+    /* Always hide cursor during grab, regardless of confineTo */
     winGrabHideCursor();
 }
 
@@ -145,6 +175,12 @@ winMasterDeactivateGrab(DeviceIntPtr dev)
         winGrabDepth = 0;
         winReleaseCursorConstraint();
         winGrabShowCursor();
+
+        /* Stop periodic timer */
+        if (g_grabTimerId) {
+            KillTimer(g_hwndGrabWindow, g_grabTimerId);
+            g_grabTimerId = 0;
+        }
     }
 
     if (winOrigMasterDeactivateGrab)
@@ -162,7 +198,21 @@ winSlaveActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoGr
         winOrigSlaveActivateGrab(dev, grab, time, autoGrab);
 
     winGrabDepth++;
-    winApplyCursorConstraint();
+    /* Only confine cursor position if grab specifies a confine window. */
+    if (grab && grab->confineTo) {
+        /* Map X11 grab window to Windows hwnd for precise constraint. */
+        WindowPtr pGrabWin = grab->confineTo ? grab->confineTo : grab->window;
+        winPrivWinPtr pWinPriv = winGetWindowPriv(pGrabWin);
+        if (pWinPriv && pWinPriv->hWnd) {
+            g_hwndGrabWindow = pWinPriv->hWnd;
+        }
+        winApplyCursorConstraint();
+        /* Windows may silently cancel ClipCursor (Win key,
+         * cursor skipping, etc.). This timer defends against it. */
+        if (!g_grabTimerId && g_hwndGrabWindow) {
+            g_grabTimerId = SetTimer(g_hwndGrabWindow, WIN_CLIPCURSOR_TIMER_ID, 10, NULL);
+        }
+    }
     winGrabHideCursor();
 }
 
@@ -177,6 +227,12 @@ winSlaveDeactivateGrab(DeviceIntPtr dev)
         winGrabDepth = 0;
         winReleaseCursorConstraint();
         winGrabShowCursor();
+
+        /* Stop periodic timer */
+        if (g_grabTimerId) {
+            KillTimer(g_hwndGrabWindow, g_grabTimerId);
+            g_grabTimerId = 0;
+        }
     }
 
     if (winOrigSlaveDeactivateGrab)

--- a/xorg-server/hw/xwin/winmouse.c
+++ b/xorg-server/hw/xwin/winmouse.c
@@ -59,6 +59,131 @@
 /* Peek the internal button mapping */
 static CARD8 const *g_winMouseButtonMap = NULL;
 
+/* Master device grab callback hooks (for Core XGrabPointer) */
+static void (*winOrigMasterActivateGrab)(DeviceIntPtr, GrabPtr, TimeStamp, Bool) = NULL;
+static void (*winOrigMasterDeactivateGrab)(DeviceIntPtr) = NULL;
+
+/* Slave device grab callback hooks (for XI2 XGrabDevice) */
+static void (*winOrigSlaveActivateGrab)(DeviceIntPtr, GrabPtr, TimeStamp, Bool) = NULL;
+static void (*winOrigSlaveDeactivateGrab)(DeviceIntPtr) = NULL;
+
+/* Grab nesting depth counter */
+static int winGrabDepth = 0;
+
+/*
+ * Apply cursor constraint to foreground window
+ */
+static void
+winApplyCursorConstraint(void)
+{
+    HWND hwnd;
+    RECT rect;
+
+    hwnd = GetForegroundWindow();
+    if (!hwnd)
+        return;
+
+    GetClientRect(hwnd, &rect);
+    ClientToScreen(hwnd, (LPPOINT)&rect.left);
+    ClientToScreen(hwnd, (LPPOINT)&rect.right);
+    ClipCursor(&rect);
+}
+
+/*
+ * Release cursor constraint
+ */
+static void
+winReleaseCursorConstraint(void)
+{
+    ClipCursor(NULL);
+}
+
+/*
+ * Force-hide cursor during grab
+ */
+static void
+winGrabHideCursor(void)
+{
+    while (ShowCursor(FALSE) >= 0)
+        ;
+}
+
+/*
+ * Force-show cursor after grab release
+ */
+static void
+winGrabShowCursor(void)
+{
+    while (ShowCursor(TRUE) < 0)
+        ;
+}
+
+/*
+ * Master device ActivateGrab hook.
+ * SDL2 X11 backend uses XGrabPointer (Core protocol), which operates
+ * on the MASTER pointer device. This hook handles that path.
+ */
+static void
+winMasterActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoGrab)
+{
+    if (winOrigMasterActivateGrab)
+        winOrigMasterActivateGrab(dev, grab, time, autoGrab);
+
+    winGrabDepth++;
+    winApplyCursorConstraint();
+    winGrabHideCursor();
+}
+
+/*
+ * Master device DeactivateGrab hook.
+ */
+static void
+winMasterDeactivateGrab(DeviceIntPtr dev)
+{
+    winGrabDepth--;
+    if (winGrabDepth <= 0) {
+        winGrabDepth = 0;
+        winReleaseCursorConstraint();
+        winGrabShowCursor();
+    }
+
+    if (winOrigMasterDeactivateGrab)
+        winOrigMasterDeactivateGrab(dev);
+}
+
+/*
+ * Slave device ActivateGrab hook.
+ * XI2 XGrabDevice may operate on slave devices directly.
+ */
+static void
+winSlaveActivateGrab(DeviceIntPtr dev, GrabPtr grab, TimeStamp time, Bool autoGrab)
+{
+    if (winOrigSlaveActivateGrab)
+        winOrigSlaveActivateGrab(dev, grab, time, autoGrab);
+
+    winGrabDepth++;
+    winApplyCursorConstraint();
+    winGrabHideCursor();
+}
+
+/*
+ * Slave device DeactivateGrab hook.
+ */
+static void
+winSlaveDeactivateGrab(DeviceIntPtr dev)
+{
+    winGrabDepth--;
+    if (winGrabDepth <= 0) {
+        winGrabDepth = 0;
+        winReleaseCursorConstraint();
+        winGrabShowCursor();
+    }
+
+    if (winOrigSlaveDeactivateGrab)
+        winOrigSlaveDeactivateGrab(dev);
+}
+
+
 /*
  * See Porting Layer Definition - p. 18
  * This is known as a DeviceProc
@@ -128,6 +253,23 @@ winMouseProc(DeviceIntPtr pDeviceInt, int iState)
                                 (PtrCtrlProcPtr)NoopDDA,
                                 GetMotionHistorySize(), 2, axes_labels);
 
+        /* Hook master device (for Core XGrabPointer used by SDL2) */
+        {
+            DeviceIntPtr master = inputInfo.pointer;
+            if (master && master != pDeviceInt) {
+                winOrigMasterActivateGrab = master->deviceGrab.ActivateGrab;
+                winOrigMasterDeactivateGrab = master->deviceGrab.DeactivateGrab;
+                master->deviceGrab.ActivateGrab = winMasterActivateGrab;
+                master->deviceGrab.DeactivateGrab = winMasterDeactivateGrab;
+            }
+        }
+
+        /* Hook slave device too (for XI2 XGrabDevice) */
+        winOrigSlaveActivateGrab = pDeviceInt->deviceGrab.ActivateGrab;
+        winOrigSlaveDeactivateGrab = pDeviceInt->deviceGrab.DeactivateGrab;
+        pDeviceInt->deviceGrab.ActivateGrab = winSlaveActivateGrab;
+        pDeviceInt->deviceGrab.DeactivateGrab = winSlaveDeactivateGrab;
+
         /* XInput2 clients query the master pointer's valuator mode
          * (Virtual core pointer, device 2) to determine how to
          * interpret XI_RawMotion values. Mode must be Relative for
@@ -156,6 +298,12 @@ winMouseProc(DeviceIntPtr pDeviceInt, int iState)
 
     case DEVICE_OFF:
         pDevice->on = FALSE;
+
+        if (winGrabDepth > 0) {
+            winGrabDepth = 0;
+            winReleaseCursorConstraint();
+            winGrabShowCursor();
+        }
         break;
     }
     return Success;

--- a/xorg-server/hw/xwin/winmouse.c
+++ b/xorg-server/hw/xwin/winmouse.c
@@ -48,6 +48,14 @@
 #include "xserver-properties.h"
 #include "inpututils.h"
 
+
+/* Prevent POINTER_ABSOLUTE events from generating XI_RawMotion.
+ * Only POINTER_RELATIVE events should produce XI_RawMotion for
+ * XInput2 relative-mode clients (SDL2, etc.). */
+#ifndef POINTER_NORAW
+#define POINTER_NORAW 0x20
+#endif
+
 /* Peek the internal button mapping */
 static CARD8 const *g_winMouseButtonMap = NULL;
 
@@ -119,6 +127,21 @@ winMouseProc(DeviceIntPtr pDeviceInt, int iState)
                                 btn_labels,
                                 (PtrCtrlProcPtr)NoopDDA,
                                 GetMotionHistorySize(), 2, axes_labels);
+
+        /* XInput2 clients query the master pointer's valuator mode
+         * (Virtual core pointer, device 2) to determine how to
+         * interpret XI_RawMotion values. Mode must be Relative for
+         * SDL2 relative mouse mode to work correctly.
+         * The slave (Windows pointer, device 6) mode is set
+         * automatically by InitPointerDeviceStruct, but the master
+         * mode must be updated explicitly.
+         */
+        if (inputInfo.pointer && inputInfo.pointer->valuator &&
+            inputInfo.pointer->valuator->numAxes >= 2) {
+            inputInfo.pointer->valuator->axes[0].mode = Relative;
+            inputInfo.pointer->valuator->axes[1].mode = Relative;
+        }
+
         free(map);
 
         g_winMouseButtonMap = pDeviceInt->button->map;
@@ -333,11 +356,38 @@ winEnqueueMotion(int x, int y)
     int valuators[2];
     ValuatorMask mask;
 
+    valuator_mask_zero(&mask);
+
     valuators[0] = x;
     valuators[1] = y;
 
     valuator_mask_set_range(&mask, 0, 2, valuators);
     QueuePointerEvents(g_pwinPointer, MotionNotify, 0,
-                       POINTER_ABSOLUTE | POINTER_SCREEN, &mask);
+                       POINTER_ABSOLUTE | POINTER_SCREEN | POINTER_NORAW, &mask);
+                       /* ADD POINTER_NORAW */
 
+}
+
+/*
+ * Enqueue a raw motion event with relative coordinates.
+ *
+ * WM_INPUT delivers hardware-level relative displacement (lLastX/Y)
+ * via GetRawInputData. We inject it into the X server's
+ * POINTER_RELATIVE pipeline so XInput2 generates XI_RawMotion
+ * events for clients in relative mouse mode.
+ */
+void
+winEnqueueRawMotion(int dx, int dy)
+{
+    int valuators[2];
+    ValuatorMask mask;
+
+    valuator_mask_zero(&mask);
+
+    valuators[0] = dx;
+    valuators[1] = dy;
+
+    valuator_mask_set_range(&mask, 0, 2, valuators);
+    QueuePointerEvents(g_pwinPointer, MotionNotify, 0,
+                       POINTER_RELATIVE, &mask);
 }

--- a/xorg-server/hw/xwin/winwndproc.c
+++ b/xorg-server/hw/xwin/winwndproc.c
@@ -1088,6 +1088,14 @@ winWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
         /* Remove our keyboard hook if it is installed */
         winRemoveKeyboardHookLL();
+
+        /* Safety: release cursor constraint if focus leaves while grabbed */
+        if (inputInfo.pointer && inputInfo.pointer->deviceGrab.grab) {
+            ClipCursor(NULL);
+            while (ShowCursor(TRUE) < 0)
+                ;
+        }
+
         return 0;
 
     case WM_SYSKEYDOWN:
@@ -1228,11 +1236,35 @@ winWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
         /* Activate or deactivate */
         s_pScreenPriv->fActive = wParam;
 
-        /* Reshow the Windows mouse cursor if we are being deactivated */
-        if (g_fSoftwareCursor && !s_pScreenPriv->fActive && !g_fCursor) {
-            /* Show Windows cursor */
-            g_fCursor = TRUE;
-            ShowCursor(TRUE);
+        if (!s_pScreenPriv->fActive) {
+            /* DEACTIVATING */
+            if (inputInfo.pointer && inputInfo.pointer->deviceGrab.grab) {
+                ClipCursor(NULL);
+                while (ShowCursor(TRUE) < 0)
+                    ;
+            }
+            else {
+                /* Original logic: restore hover-hidden cursor */
+                if (g_fSoftwareCursor && !g_fCursor) {
+                    g_fCursor = TRUE;
+                    ShowCursor(TRUE);
+                }
+            }
+        }
+        else {
+            /* ACTIVATING */
+            if (inputInfo.pointer && inputInfo.pointer->deviceGrab.grab) {
+                HWND hwndFG = GetForegroundWindow();
+                if (hwndFG) {
+                    RECT rect;
+                    GetClientRect(hwndFG, &rect);
+                    ClientToScreen(hwndFG, (LPPOINT)&rect.left);
+                    ClientToScreen(hwndFG, (LPPOINT)&rect.right);
+                    ClipCursor(&rect);
+                }
+                while (ShowCursor(FALSE) >= 0)
+                    ;
+            }
         }
 
         /* Call engine specific screen activation/deactivation function */

--- a/xorg-server/hw/xwin/winwndproc.c
+++ b/xorg-server/hw/xwin/winwndproc.c
@@ -223,6 +223,27 @@ winWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
             winInitNotifyIcon(s_pScreenPriv,FALSE);
         }
+
+        /* Register for WM_INPUT (Raw Input) mouse events.
+         * These provide hardware-level relative displacement
+         * (lLastX/Y), independent of cursor position or screen
+         * boundaries, needed for XInput2 XI_RawMotion.
+         * dwFlags=0: receive only when focused; do NOT use
+         * RIDEV_NOLEGACY (breaks WM_MOUSEMOVE for absolute mode).
+         */
+        {
+            RAWINPUTDEVICE rid;
+            rid.usUsagePage = 0x01;       /* Generic Desktop Controls */
+            rid.usUsage = 0x02;           /* Mouse */
+            rid.dwFlags = 0;              /* Focused window only */
+            rid.hwndTarget = hwnd;
+            if (!RegisterRawInputDevices(&rid, 1, sizeof(rid))) {
+                ErrorF("winWindowProc - WM_CREATE: "
+                       "RegisterRawInputDevices failed (error %lu)\n",
+                       GetLastError());
+            }
+        }
+
         return 0;
 
     case WM_DISPLAYCHANGE:
@@ -770,6 +791,43 @@ winWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
         /* Redraw the screen */
         (*s_pScreenPriv->pwinRedrawScreen) (s_pScreen);
         return 0;
+    }
+
+    case WM_INPUT:
+    {
+        RAWINPUT raw;
+        UINT rawSize = sizeof(raw);
+
+        /* We can't do anything without privates or pointer */
+        if (s_pScreenPriv == NULL || s_pScreenInfo->fIgnoreInput)
+            break;
+        if (g_pwinPointer == NULL)
+            break;
+
+        if (GetRawInputData((HRAWINPUT)lParam, RID_INPUT, &raw,
+                            &rawSize, sizeof(RAWINPUTHEADER)) == (UINT)-1) {
+            ErrorF("winWindowProc - WM_INPUT: GetRawInputData failed\n");
+            break;
+        }
+
+        if (raw.header.dwType == RIM_TYPEMOUSE) {
+            LONG dx = raw.data.mouse.lLastX;
+            LONG dy = raw.data.mouse.lLastY;
+
+            if (dx != 0 || dy != 0) {
+                /* Filter absolute-position devices (touchscreens,
+                 * tablets). They use the same Raw Input API but
+                 * deliver absolute coordinates, not relative deltas. */
+                if (!(raw.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE)) {
+                    winEnqueueRawMotion((int)dx, (int)dy);
+                }
+            }
+        }
+
+        /* Must break (not return 0) so DefWindowProc cleans up
+         * Raw Input resources. Return 0 causes resource leak and
+         * eventual Raw Input failure. */
+        break;
     }
 
     case WM_MOUSEMOVE:

--- a/xorg-server/hw/xwin/winwndproc.c
+++ b/xorg-server/hw/xwin/winwndproc.c
@@ -1041,6 +1041,26 @@ winWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
             if (g_fButton[2] && !wR)
                 PostMessage(hwnd, WM_RBUTTONUP, wCtrl | wL | wM | wShift, lPos);
         }
+
+        case WIN_CLIPCURSOR_TIMER_ID:
+        {
+            if (inputInfo.pointer &&
+                inputInfo.pointer->deviceGrab.grab &&
+                g_hwndGrabWindow) {
+                /* Windows may silently cancel it (cursor skipping,
+                * Win key, system notifications, etc.). */
+                RECT rect;
+                GetClientRect(g_hwndGrabWindow, &rect);
+                ClientToScreen(g_hwndGrabWindow, (LPPOINT)&rect.left);
+                ClientToScreen(g_hwndGrabWindow, (LPPOINT)&rect.right);
+                /* 1px padding: keep cursor away from sizing border */
+                rect.left   += 1;
+                rect.top    += 1;
+                rect.right  -= 1;
+                rect.bottom -= 1;
+                ClipCursor(&rect);
+            }
+        }
         }
         return 0;
 
@@ -1088,13 +1108,6 @@ winWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
         /* Remove our keyboard hook if it is installed */
         winRemoveKeyboardHookLL();
-
-        /* Safety: release cursor constraint if focus leaves while grabbed */
-        if (inputInfo.pointer && inputInfo.pointer->deviceGrab.grab) {
-            ClipCursor(NULL);
-            while (ShowCursor(TRUE) < 0)
-                ;
-        }
 
         return 0;
 
@@ -1254,12 +1267,16 @@ winWindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
         else {
             /* ACTIVATING */
             if (inputInfo.pointer && inputInfo.pointer->deviceGrab.grab) {
-                HWND hwndFG = GetForegroundWindow();
-                if (hwndFG) {
+                if (g_hwndGrabWindow) {
                     RECT rect;
-                    GetClientRect(hwndFG, &rect);
-                    ClientToScreen(hwndFG, (LPPOINT)&rect.left);
-                    ClientToScreen(hwndFG, (LPPOINT)&rect.right);
+                    GetClientRect(g_hwndGrabWindow, &rect);
+                    ClientToScreen(g_hwndGrabWindow, (LPPOINT)&rect.left);
+                    ClientToScreen(g_hwndGrabWindow, (LPPOINT)&rect.right);
+                    /* 1px padding: keep cursor away from sizing border */
+                    rect.left   += 1;
+                    rect.top    += 1;
+                    rect.right  -= 1;
+                    rect.bottom -= 1;
                     ClipCursor(&rect);
                 }
                 while (ShowCursor(FALSE) >= 0)


### PR DESCRIPTION
This PR fixes #77 by implementing the missing pieces for SDL2 relative mouse mode support in the `hw/xwin` DDX layer.

### What's fixed

| Problem | Before | After |
|---------|--------|-------|
| No relative displacement data | `XI_RawMotion` events never generated | Hardware-level relative deltas fed via `WM_INPUT` -> `winEnqueueRawMotion()` |
| Cursor not confined on grab | `XGrabPointer` with `confine_to` had no effect | `ClipCursor()` applied with 1px padding on grab, released on ungrab |
| Cursor not hidden on grab | `XFixesHideCursor` had no effect | `ShowCursor(FALSE)` loop on grab, restored on ungrab |
| Cursor not hidden via empty cursor | All-zero-mask cursor left the previous cursor image on screen | Renders fully transparent; cursor actually disappears |

### How it works

**1. Raw Input for relative deltas**
- Register for `WM_INPUT` (Raw Input) at `WM_CREATE`
- Extract `lLastX`/`lLastY` from `GetRawInputData()` in `WM_INPUT` handler
- New `winEnqueueRawMotion()` enqueues `POINTER_RELATIVE` events -> DIX generates `XI_RawMotion`
- Filter `MOUSE_MOVE_ABSOLUTE` devices (touchscreens) to avoid mixing absolute data
- Add `POINTER_NORAW` to `winEnqueueMotion()` so `WM_MOUSEMOVE` absolute coordinates don't pollute `XI_RawMotion`

**2. Master valuator mode = Relative**
- SDL2 queries the master pointer's (device 2) valuator mode to decide how to interpret raw values
- Set `inputInfo.pointer->valuator->axes[*].mode = Relative` in `DEVICE_INIT`

**3. Cursor confinement and hide via grab hooks**
- Hook `ActivateGrab`/`DeactivateGrab` on both master and slave devices
- Only act when `grab->confineTo` is set (avoids interfering with implicit grabs)
- Map `confineTo` window -> `HWND` via `winGetWindowPriv()` for precise clipping
- 10ms `ClipCursor` re-apply timer defends against Windows silently canceling it (cursor skip, Win key, notifications)
- `WM_ACTIVATEAPP` handles app-level activate/deactivate: temporarily release constraint on Alt+Tab, restore on return

**4. Empty-mask cursor hiding**
- Empty (all-zero mask) cursors are how X clients hide the cursor outside of grabs (SDL seamless mode)
- Set `showTransparent = TRUE` in `winInitCursor()` so they reach `winLoadCursor()` instead of being converted to `NullCursor` (same approach as xf86 `HARDWARE_CURSOR_SHOW_TRANSPARENT`)
- Fix the `emptyMask` branch to render fully transparent (AND all-ones, XOR all-zeros) instead of black pixels
- Logically independent of the relative-mode fixes — can be cherry-picked separately (`8e100944f`)

### Files changed

- `hw/xwin/win.h` — declarations for `WIN_CLIPCURSOR_TIMER_ID`, `g_hwndGrabWindow`, `winEnqueueRawMotion()`
- `hw/xwin/winmouse.c` — Raw Input injection, grab hooks, cursor constraint/hide logic, valuator mode fix
- `hw/xwin/winwndproc.c` — `WM_INPUT` handler, `WM_TIMER` re-apply, `WM_ACTIVATEAPP` grab-aware rewrite
- `hw/xwin/wincursor.c` — empty-mask cursors render fully transparent (`showTransparent` + fixed `emptyMask` branch)

### Testing

- `xinput test-xi2 --root` shows `RawMotion` events with correct deltas
- AssaultCube: mouse capture works without `SDL_MOUSE_RELATIVE_MODE_WARP`, no audio stutter
- dosbox-staging: Ctrl+F10 capture/release cycle works correctly
- xterm regression test: normal mouse behavior unaffected
- 1x1 all-zero cursor repro (what SDL uses to hide the pointer): pointer becomes fully invisible; normal cursors unaffected

Fixes #77